### PR TITLE
Improve logging when setting values are equal.

### DIFF
--- a/Publish-BiztalkBtdfApplication.psm1
+++ b/Publish-BiztalkBtdfApplication.psm1
@@ -1154,8 +1154,12 @@ function Substitute-XmlSettingsFileValues() {
         if ($null -ne $xmlProperty) {
             $newValue = $substituteSettings[$key]
             $existingValue = $xmlProperty.Node.InnerText
-            $xmlProperty.Node.InnerText = $newValue
-            Write-Output "Property ""$key"" got new value ""$newValue"" for existing value ""$existingValue"""
+            if ($newValue -eq $existingValue) {
+                Write-Output "Property ""$key"" already has value ""$newValue"""
+            } else {
+                $xmlProperty.Node.InnerText = $newValue
+                Write-Output "Property ""$key"" got new value ""$newValue"" for existing value ""$existingValue"""
+            }
         } else {
             Write-Verbose "Found no existing property named ""$key"""
         }


### PR DESCRIPTION
For issue #8 
When values in Octopus are equal to the values they are supposed to substitute, log a message describing this instead of making it look like the values are updated.

Might be useful if logs are investigated to understand why a certain value has been used.